### PR TITLE
fix: also use table name to find correct relation to alter

### DIFF
--- a/schema/diff.go
+++ b/schema/diff.go
@@ -593,7 +593,7 @@ func (s *PatchSchema) Build(from, to *Schema) {
 		pt := &PatchRelation{
 			from: r,
 		}
-		rt, err := to.FindRelation(r.Columns, r.ParentColumns)
+		rt, err := to.FindRelation(r.Table.Name, r.Columns, r.ParentColumns)
 		if err == nil {
 			pt.to = rt
 		}
@@ -604,7 +604,7 @@ func (s *PatchSchema) Build(from, to *Schema) {
 		pt := &PatchRelation{
 			to: r,
 		}
-		_, err := from.FindRelation(r.Columns, r.ParentColumns)
+		_, err := from.FindRelation(r.Table.Name, r.Columns, r.ParentColumns)
 		if err != nil {
 			s.relations = append(s.relations, pt)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -116,10 +116,10 @@ func (s *Schema) FindTableByName(name string) (*Table, error) {
 }
 
 // FindRelation ...
-func (s *Schema) FindRelation(cs, pcs []*Column) (*Relation, error) {
+func (s *Schema) FindRelation(tblName string, cs, pcs []*Column) (*Relation, error) {
 L:
 	for _, r := range s.Relations {
-		if len(r.Columns) != len(cs) || len(r.ParentColumns) != len(pcs) {
+		if len(r.Columns) != len(cs) || len(r.ParentColumns) != len(pcs) || r.Table.Name != tblName {
 			continue
 		}
 		for _, rc := range r.Columns {


### PR DESCRIPTION
Right now if there are multiple tables with "parent_id" relation to the same parent table, the diff returns the first match and the alter table fails. 

This fix adds a table name check to the relation finder so that the diffs don't find relations in other tables that have similar column names. 