### PR TITLE
fix: avoid panic when parsing the create index on timestamp with/without time zone

### DIFF
--- a/drivers/postgres/idxscan/idxscan.go
+++ b/drivers/postgres/idxscan/idxscan.go
@@ -41,7 +41,7 @@ func ParseCreateIndex(s string) IndexDef {
 		idxwith := strings.Index(utail, "WITH")
 		idxtbsp := strings.Index(utail, "TABLESPACE")
 		idxwhere := strings.Index(utail, "WHERE")
-		if idxwith >= 0 {
+		if idxwith >= 0 && idxwith < idxwhere { // avoid matching timestamp with/without time zone in where clause
 			idxto := len(tail)
 			if idxwhere >= 0 {
 				idxto = idxwhere

--- a/drivers/postgres/idxscan/idxscan.go
+++ b/drivers/postgres/idxscan/idxscan.go
@@ -41,7 +41,7 @@ func ParseCreateIndex(s string) IndexDef {
 		idxwith := strings.Index(utail, "WITH")
 		idxtbsp := strings.Index(utail, "TABLESPACE")
 		idxwhere := strings.Index(utail, "WHERE")
-		if idxwith >= 0 && idxwith < idxwhere { // avoid matching timestamp with/without time zone in where clause
+		if idxwith >= 0 && (idxwith < idxwhere || idxwhere < 0) { // avoid matching timestamp with/without time zone in where clause
 			idxto := len(tail)
 			if idxwhere >= 0 {
 				idxto = idxwhere

--- a/drivers/postgres/idxscan/idxscan_test.go
+++ b/drivers/postgres/idxscan/idxscan_test.go
@@ -86,3 +86,27 @@ func TestParseCreateIndex_WithAndTimestampWithoutTimezone(t *testing.T) {
 		t.Errorf("%#v", ss)
 	}
 }
+
+func TestParseCreateIndex_NoWhere(t *testing.T) {
+	s := `CREATE UNIQUE INDEX \"IX_customer_external_id\"
+	ON public.customer
+	USING btree (external_id)
+	WITH a= b`
+
+	ss := ParseCreateIndex(s)
+	eq := IndexDef{
+		Name:         "\\\"IX_customer_external_id\\\"",
+		Table:        "public.customer",
+		Unique:       true,
+		Concurrently: false,
+		UsingType:    "btree",
+		ColDef:       "(external_id)",
+		With:         "a= b",
+		Tablespace:   "",
+		Where:        "",
+	}
+
+	if !reflect.DeepEqual(ss, eq) {
+		t.Errorf("%#v", ss)
+	}
+}

--- a/drivers/postgres/idxscan/idxscan_test.go
+++ b/drivers/postgres/idxscan/idxscan_test.go
@@ -5,22 +5,22 @@ import (
 	"testing"
 )
 
-const testingQ = `  CREATE	UNiQUE
- INDEX	uk_candidate_recruiter_info_email	ON public.candidate
- USING btree
- (		sdih COLLATE "ru_RU" int4 ASC NULLS LAST,
- asfg COLLATE "ru_RU" DESC,
- ertny,
- ((recruiter_info ->>
- 'email'::text))
- )
-
- WITH a= b, c = d,e=f
- TABLESPACE f
- WHERE as;roug (hblkas) bfdvvkjhb (3li54f9q3er opfbg78 9)erg`
-
 func TestParseCreateIndex(t *testing.T) {
-	ss := ParseCreateIndex(testingQ)
+	s := `  CREATE	UNiQUE
+	INDEX	uk_candidate_recruiter_info_email	ON public.candidate
+	USING btree
+	(		sdih COLLATE "ru_RU" int4 ASC NULLS LAST,
+	asfg COLLATE "ru_RU" DESC,
+	ertny,
+	((recruiter_info ->>
+	'email'::text))
+	)
+ 
+	WITH a= b, c = d,e=f
+	TABLESPACE f
+	WHERE as;roug (hblkas) bfdvvkjhb (3li54f9q3er opfbg78 9)erg`
+
+	ss := ParseCreateIndex(s)
 	eq := IndexDef{
 		Name:         "uk_candidate_recruiter_info_email",
 		Table:        "public.candidate",
@@ -32,6 +32,56 @@ func TestParseCreateIndex(t *testing.T) {
 		Tablespace:   "f",
 		Where:        "as;roug (hblkas) bfdvvkjhb (3li54f9q3er opfbg78 9)erg",
 	}
+
+	if !reflect.DeepEqual(ss, eq) {
+		t.Errorf("%#v", ss)
+	}
+}
+
+func TestParseCreateIndex_NoWithAndTimestampWithTimezone(t *testing.T) {
+	s := `CREATE UNIQUE INDEX \"IX_customer_external_id\"
+	ON public.customer
+	USING btree (external_id)
+	WHERE (created > '2020-09-27 20:00:00.000000'::timestamp with time zone)`
+
+	ss := ParseCreateIndex(s)
+	eq := IndexDef{
+		Name:         "\\\"IX_customer_external_id\\\"",
+		Table:        "public.customer",
+		Unique:       true,
+		Concurrently: false,
+		UsingType:    "btree",
+		ColDef:       "(external_id)",
+		With:         "",
+		Tablespace:   "",
+		Where:        "(created > '2020-09-27 20:00:00.000000'::timestamp with time zone)",
+	}
+
+	if !reflect.DeepEqual(ss, eq) {
+		t.Errorf("%#v", ss)
+	}
+}
+
+func TestParseCreateIndex_WithAndTimestampWithoutTimezone(t *testing.T) {
+	s := `CREATE UNIQUE INDEX \"IX_customer_external_id\"
+	ON public.customer
+	USING btree (external_id)
+	WITH a= b
+	WHERE (created > '2020-09-27 20:00:00.000000'::timestamp without time zone)`
+
+	ss := ParseCreateIndex(s)
+	eq := IndexDef{
+		Name:         "\\\"IX_customer_external_id\\\"",
+		Table:        "public.customer",
+		Unique:       true,
+		Concurrently: false,
+		UsingType:    "btree",
+		ColDef:       "(external_id)",
+		With:         "a= b",
+		Tablespace:   "",
+		Where:        "(created > '2020-09-27 20:00:00.000000'::timestamp without time zone)",
+	}
+
 	if !reflect.DeepEqual(ss, eq) {
 		t.Errorf("%#v", ss)
 	}


### PR DESCRIPTION
When running the latest version of `goerd` against a schema that has a WHERE clause specifying timestamp with/without timezone, it would panic.

```
panic: runtime error: slice bounds out of range [62:1]

goroutine 1 [running]:
github.com/covrom/goerd/drivers/postgres/idxscan.ParseCreateIndex({0x14000216540?, 0x1400003d878?})
        /Users/user/go/pkg/mod/github.com/covrom/goerd@v1.1.1/drivers/postgres/idxscan/idxscan.go:53 +0x448
github.com/covrom/goerd/drivers/postgres.(*Postgres).Analyze(0x1400003db58, 0x14000146a00)
        /Users/user/go/pkg/mod/github.com/covrom/goerd@v1.1.1/drivers/postgres/postgres.go:253 +0x22f0
github.com/covrom/goerd/datasource.Analyze({0x16d3769c4, 0x84})
        /Users/user/go/pkg/mod/github.com/covrom/goerd@v1.1.1/datasource/datasource.go:24 +0x1d4
github.com/covrom/goerd.SchemaFromPostgresWithConnect(...)
        /Users/user/go/pkg/mod/github.com/covrom/goerd@v1.1.1/goerd.go:14
main.main()
        /Users/user/go/pkg/mod/github.com/covrom/goerd@v1.1.1/cmd/goerd/main.go:185 +0xd34
```

This is because with `utail` we index on `WITH`, and that ends up matching the `WITH` or `WITHOUT` in the WHERE clause.

Can be reproduced and validated with the newly added unit tests.